### PR TITLE
Add categories for books and papers

### DIFF
--- a/lib/lighthouse/books/query.ex
+++ b/lib/lighthouse/books/query.ex
@@ -1,4 +1,4 @@
-defmodule Lighthouse.Books.Repository do
+defmodule Lighthouse.Books.Query do
   import Ecto.Query
   alias Lighthouse.Repo
   alias Lighthouse.Books.Book

--- a/lib/lighthouse/books/query.ex
+++ b/lib/lighthouse/books/query.ex
@@ -9,7 +9,6 @@ defmodule Lighthouse.Books.Query do
     query = from b in Book, where: b.slug == ^slug, select: b
 
     Repo.one(query)
-    |> wrap
   end
 
   def update_book(book, data) do
@@ -18,16 +17,9 @@ defmodule Lighthouse.Books.Query do
     |> Repo.update!
   end
 
-  def delete_all do
-    Repo.delete_all(Book)
-  end
-
   def search(keyword) do
     wrapped = "%#{keyword}%"
     query = from b in Book, where: like(b.title, ^wrapped), select: b
     Repo.all(query)
   end
-
-  defp wrap(nil),    do: {:not_found, nil}
-  defp wrap(entity), do: {:ok, entity}
 end

--- a/lib/lighthouse/books/repository.ex
+++ b/lib/lighthouse/books/repository.ex
@@ -28,8 +28,6 @@ defmodule Lighthouse.Books.Repository do
     Repo.all(query)
   end
 
-  def save(book), do: Repo.insert!(book)
-
   defp wrap(nil),    do: {:not_found, nil}
   defp wrap(entity), do: {:ok, entity}
 end

--- a/lib/lighthouse/categories/categories_for_book.ex
+++ b/lib/lighthouse/categories/categories_for_book.ex
@@ -1,0 +1,8 @@
+defmodule Lighthouse.Categories.CategoriesForBook do
+  use Ecto.Model
+
+  schema "categories_for_books" do
+    field :category_id, :integer
+    field :book_id,     :integer
+  end
+end

--- a/lib/lighthouse/categories/categories_for_paper.ex
+++ b/lib/lighthouse/categories/categories_for_paper.ex
@@ -1,0 +1,8 @@
+defmodule Lighthouse.Categories.CategoriesForPaper do
+  use Ecto.Model
+
+  schema "categories_for_papers" do
+    field :category_id, :integer
+    field :paper_id,     :integer
+  end
+end

--- a/lib/lighthouse/categories/categories_for_paper.ex
+++ b/lib/lighthouse/categories/categories_for_paper.ex
@@ -3,6 +3,6 @@ defmodule Lighthouse.Categories.CategoriesForPaper do
 
   schema "categories_for_papers" do
     field :category_id, :integer
-    field :paper_id,     :integer
+    field :paper_id,    :integer
   end
 end

--- a/lib/lighthouse/categories/category.ex
+++ b/lib/lighthouse/categories/category.ex
@@ -1,0 +1,7 @@
+defmodule Lighthouse.Categories.Category do
+  use Ecto.Model
+
+  schema "categories" do
+    field :name
+  end
+end

--- a/lib/lighthouse/categories/category_for.ex
+++ b/lib/lighthouse/categories/category_for.ex
@@ -1,0 +1,6 @@
+defprotocol Lighthouse.Categories.CategoryFor do
+
+  def save_relation(thing, category)
+
+  def find_categories_for(thing)
+end

--- a/lib/lighthouse/categories/category_for_book.ex
+++ b/lib/lighthouse/categories/category_for_book.ex
@@ -1,0 +1,23 @@
+defimpl Lighthouse.Categories.CategoryFor, for: Lighthouse.Books.Book do
+  import Ecto.Query
+  alias Lighthouse.Repo
+  alias Lighthouse.Books.Book
+  alias Lighthouse.Categories.Category
+  alias Lighthouse.Categories.CategoriesForBook
+
+  def save_relation(%Book{id: book_id}, %Category{id: category_id}) do
+    relation = %CategoriesForBook{category_id: category_id, book_id: book_id}
+
+    Repo.insert!(relation)
+  end
+
+  def find_categories_for(%Book{id: book_id}) do
+    query = from b in Book,
+            join: cfb in CategoriesForBook, on: b.id == cfb.book_id,
+            join: c in Category, on: c.id == cfb.category_id,
+            where: b.id == ^book_id,
+            select: c
+
+    Repo.all(query)
+  end
+end

--- a/lib/lighthouse/categories/category_for_book.ex
+++ b/lib/lighthouse/categories/category_for_book.ex
@@ -6,9 +6,8 @@ defimpl Lighthouse.Categories.CategoryFor, for: Lighthouse.Books.Book do
   alias Lighthouse.Categories.CategoriesForBook
 
   def save_relation(%Book{id: book_id}, %Category{id: category_id}) do
-    relation = %CategoriesForBook{category_id: category_id, book_id: book_id}
-
-    Repo.insert!(relation)
+    %CategoriesForBook{category_id: category_id, book_id: book_id}
+    |> Repo.insert!
   end
 
   def find_categories_for(%Book{id: book_id}) do

--- a/lib/lighthouse/categories/category_for_paper.ex
+++ b/lib/lighthouse/categories/category_for_paper.ex
@@ -1,0 +1,23 @@
+defimpl Lighthouse.Categories.CategoryFor, for: Lighthouse.Papers.Paper do
+  import Ecto.Query
+  alias Lighthouse.Repo
+  alias Lighthouse.Papers.Paper
+  alias Lighthouse.Categories.Category
+  alias Lighthouse.Categories.CategoriesForPaper
+
+  def save_relation(%Paper{id: paper_id}, %Category{id: category_id}) do
+    relation = %CategoriesForPaper{category_id: category_id, paper_id: paper_id}
+
+    Repo.insert!(relation)
+  end
+
+  def find_categories_for(%Paper{id: paper_id}) do
+    query = from p in Paper,
+            join: cfp in CategoriesForPaper, on: p.id == cfp.paper_id,
+            join: c in Category, on: c.id == cfp.category_id,
+            where: p.id == ^paper_id,
+            select: c
+
+    Repo.all(query)
+  end
+end

--- a/lib/lighthouse/categories/category_for_paper.ex
+++ b/lib/lighthouse/categories/category_for_paper.ex
@@ -6,9 +6,8 @@ defimpl Lighthouse.Categories.CategoryFor, for: Lighthouse.Papers.Paper do
   alias Lighthouse.Categories.CategoriesForPaper
 
   def save_relation(%Paper{id: paper_id}, %Category{id: category_id}) do
-    relation = %CategoriesForPaper{category_id: category_id, paper_id: paper_id}
-
-    Repo.insert!(relation)
+    %CategoriesForPaper{category_id: category_id, paper_id: paper_id}
+    |> Repo.insert!
   end
 
   def find_categories_for(%Paper{id: paper_id}) do

--- a/lib/lighthouse/categories/repository.ex
+++ b/lib/lighthouse/categories/repository.ex
@@ -4,8 +4,6 @@ defmodule Lighthouse.Categories.Repository do
   alias Lighthouse.Categories.Category
   alias Lighthouse.Categories.CategoryFor
 
-  def save(category), do: Repo.insert!(category)
-
   def save_relation(category_name, thing) do
     category = find_by_name(category_name)
     CategoryFor.save_relation(thing, category)

--- a/lib/lighthouse/categories/repository.ex
+++ b/lib/lighthouse/categories/repository.ex
@@ -1,50 +1,22 @@
 defmodule Lighthouse.Categories.Repository do
   import Ecto.Query
   alias Lighthouse.Repo
-  alias Lighthouse.Books.Book
-  alias Lighthouse.Papers.Paper
   alias Lighthouse.Categories.Category
-  alias Lighthouse.Categories.CategoriesForBook
-  alias Lighthouse.Categories.CategoriesForPaper
+  alias Lighthouse.Categories.CategoryFor
 
   def save(category), do: Repo.insert!(category)
 
-  def save_relation(category_name, %Book{id: book_id}) do
-    %Category{id: category_id} = find_by_name(category_name)
-    relation = %CategoriesForBook{category_id: category_id, book_id: book_id}
-
-    Repo.insert!(relation)
+  def save_relation(category_name, thing) do
+    category = find_by_name(category_name)
+    CategoryFor.save_relation(thing, category)
   end
 
-  def save_relation(category_name, %Paper{id: paper_id}) do
-    %Category{id: category_id} = find_by_name(category_name)
-    relation = %CategoriesForPaper{category_id: category_id, paper_id: paper_id}
-
-    Repo.insert!(relation)
+  def find_categories_for(thing) do
+    CategoryFor.find_categories_for(thing)
   end
 
   defp find_by_name(name) do
     query = from c in Category, where: c.name == ^name, select: c
     Repo.one(query)
-  end
-
-  def find_categories_for(%Book{id: book_id}) do
-    query = from b in Book,
-            join: cfb in CategoriesForBook, on: b.id == cfb.book_id,
-            join: c in Category, on: c.id == cfb.category_id,
-            where: b.id == ^book_id,
-            select: c
-
-    Repo.all(query)
-  end
-
-  def find_categories_for(%Paper{id: paper_id}) do
-    query = from p in Paper,
-            join: cfp in CategoriesForPaper, on: p.id == cfp.paper_id,
-            join: c in Category, on: c.id == cfp.category_id,
-            where: p.id == ^paper_id,
-            select: c
-
-    Repo.all(query)
   end
 end

--- a/lib/lighthouse/categories/repository.ex
+++ b/lib/lighthouse/categories/repository.ex
@@ -1,0 +1,31 @@
+defmodule Lighthouse.Categories.Repository do
+  import Ecto.Query
+  alias Lighthouse.Repo
+  alias Lighthouse.Books.Book
+  alias Lighthouse.Categories.Category
+  alias Lighthouse.Categories.CategoriesForBook
+
+  def save(category), do: Repo.insert!(category)
+
+  def save_relation(category_name, %Book{id: book_id}) do
+    %Category{id: category_id} = find_by_name(category_name)
+    relation = %CategoriesForBook{category_id: category_id, book_id: book_id}
+
+    Repo.insert!(relation)
+  end
+
+  defp find_by_name(name) do
+    query = from c in Category, where: c.name == ^name, select: c
+    Repo.one(query)
+  end
+
+  def find_categories_for(%Book{id: book_id}) do
+    query = from b in Book,
+            join: cfb in CategoriesForBook, on: b.id == cfb.book_id,
+            join: c in Category, on: c.id == cfb.category_id,
+            where: b.id == ^book_id,
+            select: c
+
+    Repo.all(query)
+  end
+end

--- a/lib/lighthouse/categories/repository.ex
+++ b/lib/lighthouse/categories/repository.ex
@@ -2,14 +2,23 @@ defmodule Lighthouse.Categories.Repository do
   import Ecto.Query
   alias Lighthouse.Repo
   alias Lighthouse.Books.Book
+  alias Lighthouse.Papers.Paper
   alias Lighthouse.Categories.Category
   alias Lighthouse.Categories.CategoriesForBook
+  alias Lighthouse.Categories.CategoriesForPaper
 
   def save(category), do: Repo.insert!(category)
 
   def save_relation(category_name, %Book{id: book_id}) do
     %Category{id: category_id} = find_by_name(category_name)
     relation = %CategoriesForBook{category_id: category_id, book_id: book_id}
+
+    Repo.insert!(relation)
+  end
+
+  def save_relation(category_name, %Paper{id: paper_id}) do
+    %Category{id: category_id} = find_by_name(category_name)
+    relation = %CategoriesForPaper{category_id: category_id, paper_id: paper_id}
 
     Repo.insert!(relation)
   end
@@ -24,6 +33,16 @@ defmodule Lighthouse.Categories.Repository do
             join: cfb in CategoriesForBook, on: b.id == cfb.book_id,
             join: c in Category, on: c.id == cfb.category_id,
             where: b.id == ^book_id,
+            select: c
+
+    Repo.all(query)
+  end
+
+  def find_categories_for(%Paper{id: paper_id}) do
+    query = from p in Paper,
+            join: cfp in CategoriesForPaper, on: p.id == cfp.paper_id,
+            join: c in Category, on: c.id == cfp.category_id,
+            where: p.id == ^paper_id,
             select: c
 
     Repo.all(query)

--- a/lib/lighthouse/papers/query.ex
+++ b/lib/lighthouse/papers/query.ex
@@ -1,4 +1,4 @@
-defmodule Lighthouse.Papers.Repository do
+defmodule Lighthouse.Papers.Query do
   import Ecto.Query
   alias Lighthouse.Repo
   alias Lighthouse.Papers.Paper

--- a/lib/lighthouse/papers/repository.ex
+++ b/lib/lighthouse/papers/repository.ex
@@ -5,8 +5,6 @@ defmodule Lighthouse.Papers.Repository do
 
   def all, do: Repo.all(from p in Paper, select: p)
 
-  def save(paper), do: Repo.insert!(paper)
-
   def find_by_slug(slug) do
     query = from p in Paper, where: p.slug == ^slug, select: p
     Repo.one(query)

--- a/lib/lighthouse/search/searcher.ex
+++ b/lib/lighthouse/search/searcher.ex
@@ -1,6 +1,6 @@
 defmodule Lighthouse.Searcher do
-  alias Lighthouse.Books.Repository,  as: Books
-  alias Lighthouse.Papers.Repository, as: Papers
+  alias Lighthouse.Books.Query, as: Books
+  alias Lighthouse.Papers.Query, as: Papers
 
   def look_for(keyword) do
     Books.search(keyword) ++ Papers.search(keyword)

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,7 @@
   "fs": {:hex, :fs, "0.9.2"},
   "getopt": {:hex, :getopt, "0.8.2"},
   "httpotion": {:hex, :httpotion, "2.1.0"},
-  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]},
+  "ibrowse": {:git, "https://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]},
   "mariaex": {:hex, :mariaex, "0.4.3"},
   "neotoma": {:hex, :neotoma, "1.7.3"},
   "phoenix": {:hex, :phoenix, "1.0.2"},

--- a/priv/repo/migrations/20150814125845_add_categories.exs
+++ b/priv/repo/migrations/20150814125845_add_categories.exs
@@ -1,0 +1,9 @@
+defmodule Lighthouse.Repo.Migrations.AddCategories do
+  use Ecto.Migration
+
+  def change do
+    create table(:categories) do
+      add :name, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20150814125912_add_categories_for_books.exs
+++ b/priv/repo/migrations/20150814125912_add_categories_for_books.exs
@@ -1,0 +1,10 @@
+defmodule Lighthouse.Repo.Migrations.AddCategoriesForBooks do
+  use Ecto.Migration
+
+  def change do
+    create table(:categories_for_books) do
+      add :category_id, references(:categories)
+      add :book_id,     references(:books)
+    end
+  end
+end

--- a/priv/repo/migrations/20150831200455_add_categories_for_papers.exs
+++ b/priv/repo/migrations/20150831200455_add_categories_for_papers.exs
@@ -1,0 +1,10 @@
+defmodule Lighthouse.Repo.Migrations.AddCategoriesForPapers do
+  use Ecto.Migration
+
+  def change do
+    create table(:categories_for_papers) do
+      add :category_id, references(:categories)
+      add :paper_id,     references(:papers)
+    end
+  end
+end

--- a/test/books/controller_test.exs
+++ b/test/books/controller_test.exs
@@ -3,25 +3,23 @@ defmodule Lighthouse.Books.ControllerTest do
   use Lighthouse.ConnCase
   use Lighthouse.RepositoryCase
 
-  alias Lighthouse.Books.Repository
-  alias Lighthouse.Categories.Repository, as: CategoryRepo
   alias Lighthouse.Categories.Category
 
   test "returns 200" do
-    Repository.save(sample_book())
+    sample_book() |> Repo.insert!
     conn = get conn(), "/books"
     assert html_response(conn, 200)
   end
 
   test "renders all books" do
-    book = Repository.save(sample_book())
+    book = sample_book() |> Repo.insert!
 
     conn = get conn(), "/books"
     assert html_response(conn, 200) =~ book.title
   end
 
   test "renders single book" do
-    book = Repository.save(sample_book())
+    book = sample_book() |> Repo.insert!
 
     conn = get conn(), "/books/#{book.slug}"
 
@@ -49,7 +47,7 @@ defmodule Lighthouse.Books.ControllerTest do
   end
 
   test "adds a book with a category" do
-    category = CategoryRepo.save(%Category{name: "marketing"})
+    category = %Category{name: "marketing"} |> Repo.insert!
 
     params = %{
       "isbn"        => "a",
@@ -65,14 +63,14 @@ defmodule Lighthouse.Books.ControllerTest do
   end
 
   test "has form to update book" do
-    book = Repository.save(sample_book())
+    book = sample_book() |> Repo.insert!
     conn = get conn(), "/books/#{book.slug}/edit"
     assert conn.status == 200
     assert html_response(conn, 200) =~ "Description"
   end
 
   test "updates a book" do
-    book = Repository.save(sample_book())
+    book = sample_book() |> Repo.insert!
     conn = post conn(), "/books/#{book.slug}/edit", %{book: %{title: "Updated"}}
     assert conn.status == 200
     assert html_response(conn, 200) =~ "Updated"

--- a/test/books/controller_test.exs
+++ b/test/books/controller_test.exs
@@ -2,7 +2,10 @@ defmodule Lighthouse.Books.ControllerTest do
   import Lighthouse.SampleData, only: [sample_book: 0]
   use Lighthouse.ConnCase
   use Lighthouse.RepositoryCase
+
   alias Lighthouse.Books.Repository
+  alias Lighthouse.Categories.Repository, as: CategoryRepo
+  alias Lighthouse.Categories.Category
 
   test "returns 200" do
     Repository.save(sample_book())
@@ -41,8 +44,24 @@ defmodule Lighthouse.Books.ControllerTest do
     }
     post conn(), "/books", %{book: params}
 
-    conn =  get conn(), "/books/#{params[:slug]}"
+    conn = get conn(), "/books/#{params[:slug]}"
     assert html_response(conn, 200)
+  end
+
+  test "adds a book with a category" do
+    category = CategoryRepo.save(%Category{name: "marketing"})
+
+    params = %{
+      "isbn"        => "a",
+      "title"       => "something",
+      "slug"        => "the-book",
+      "description" => "d",
+      "link"        => "e"
+    }
+    post conn(), "/books", %{book: params, category: category.name}
+
+    conn = get conn(), "/books/#{params["slug"]}"
+    assert html_response(conn, 200) =~ category.name
   end
 
   test "has form to update book" do

--- a/test/books/query_test.exs
+++ b/test/books/query_test.exs
@@ -18,13 +18,12 @@ defmodule Lighthouse.Books.QueryTest do
 
   test "can find a book" do
     book = sample_book() |> Repo.insert!
-    {:ok, found_book} = Query.find_by_slug(book.slug)
+    found_book = Query.find_by_slug(book.slug)
 
     assert found_book == book
   end
 
   test "errors if it can not be found" do
-    {error, _} = Query.find_by_slug("does-not-exist")
-    assert error == :not_found
+    assert Query.find_by_slug("does-not-exist") == nil
   end
 end

--- a/test/books/query_test.exs
+++ b/test/books/query_test.exs
@@ -1,7 +1,7 @@
-defmodule Lighthouse.Books.RepositoryTest do
+defmodule Lighthouse.Books.QueryTest do
   use Lighthouse.RepositoryCase
   import Lighthouse.SampleData, only: [sample_book: 0]
-  alias Lighthouse.Books.Repository
+  alias Lighthouse.Books.Query
 
   test "save a book to the database" do
     book = sample_book()
@@ -13,18 +13,18 @@ defmodule Lighthouse.Books.RepositoryTest do
   test "can find a book by partial title" do
     book = sample_book() |> Repo.insert!
     partial_title = book.title |> String.split |> List.first
-    assert Repository.search(partial_title) == [book]
+    assert Query.search(partial_title) == [book]
   end
 
   test "can find a book" do
     book = sample_book() |> Repo.insert!
-    {:ok, found_book} = Repository.find_by_slug(book.slug)
+    {:ok, found_book} = Query.find_by_slug(book.slug)
 
     assert found_book == book
   end
 
   test "errors if it can not be found" do
-    {error, _} = Repository.find_by_slug("does-not-exist")
+    {error, _} = Query.find_by_slug("does-not-exist")
     assert error == :not_found
   end
 end

--- a/test/books/repository_test.exs
+++ b/test/books/repository_test.exs
@@ -5,34 +5,26 @@ defmodule Lighthouse.Books.RepositoryTest do
 
   test "save a book to the database" do
     book = sample_book()
-    saved_book = Repository.save(book)
+    saved_book = book |> Repo.insert!
 
-    assert saved_book.slug == "that-book"
+    assert saved_book.slug == book.slug
   end
 
   test "can find a book by partial title" do
-    Repository.save(sample_book())
-    result = Repository.search("book")
-    assert Enum.count(result) == 1
+    book = sample_book() |> Repo.insert!
+    partial_title = book.title |> String.split |> List.first
+    assert Repository.search(partial_title) == [book]
   end
 
   test "can find a book" do
-    Repository.save(sample_book())
-    {_, book} = Repository.find_by_slug("that-book")
+    book = sample_book() |> Repo.insert!
+    {:ok, found_book} = Repository.find_by_slug(book.slug)
 
-    assert book.slug == "that-book"
+    assert found_book == book
   end
 
   test "errors if it can not be found" do
     {error, _} = Repository.find_by_slug("does-not-exist")
     assert error == :not_found
-  end
-
-  test "updates a book" do
-    the_book = Repository.save(sample_book())
-    Repository.update_book(the_book, %{title: "Updated"})
-    {:ok, book} = Repository.find_by_slug(the_book.slug)
-
-    assert book.title == "Updated"
   end
 end

--- a/test/categories/category_for_book_test.exs
+++ b/test/categories/category_for_book_test.exs
@@ -1,14 +1,11 @@
 defmodule Lighthouse.Categories.CategoryForBookTest do
   use Lighthouse.RepositoryCase
-  alias Lighthouse.Categories.Repository
   alias Lighthouse.Categories.Category
   alias Lighthouse.Categories.CategoryFor
 
-  alias Lighthouse.Books.Repository, as: BookRepository
-
   test "saves a relation to a book" do
-    book = BookRepository.save(Lighthouse.SampleData.sample_book)
-    category = Repository.save(%Category{name: "my-category"})
+    book = Lighthouse.SampleData.sample_book  |> Repo.insert!
+    category = %Category{name: "my-category"} |> Repo.insert!
 
     CategoryFor.save_relation(book, category)
 

--- a/test/categories/category_for_book_test.exs
+++ b/test/categories/category_for_book_test.exs
@@ -1,0 +1,17 @@
+defmodule Lighthouse.Categories.CategoryForBookTest do
+  use Lighthouse.RepositoryCase
+  alias Lighthouse.Categories.Repository
+  alias Lighthouse.Categories.Category
+  alias Lighthouse.Categories.CategoryFor
+
+  alias Lighthouse.Books.Repository, as: BookRepository
+
+  test "saves a relation to a book" do
+    book = BookRepository.save(Lighthouse.SampleData.sample_book)
+    category = Repository.save(%Category{name: "my-category"})
+
+    CategoryFor.save_relation(book, category)
+
+    assert CategoryFor.find_categories_for(book) == [category]
+  end
+end

--- a/test/categories/category_for_paper_test.exs
+++ b/test/categories/category_for_paper_test.exs
@@ -4,10 +4,8 @@ defmodule Lighthouse.Categories.CategoryForPaperTest do
   alias Lighthouse.Categories.Category
   alias Lighthouse.Categories.CategoryFor
 
-  alias Lighthouse.Papers.Repository, as: PaperRepository
-
   test "saves a relation to a paper" do
-    paper = PaperRepository.save(Lighthouse.SampleData.sample_paper)
+    paper = Lighthouse.SampleData.sample_paper |> Repo.insert!
     category = Repository.save(%Category{name: "my-category"})
 
     CategoryFor.save_relation(paper, category)

--- a/test/categories/category_for_paper_test.exs
+++ b/test/categories/category_for_paper_test.exs
@@ -1,0 +1,17 @@
+defmodule Lighthouse.Categories.CategoryForPaperTest do
+  use Lighthouse.RepositoryCase
+  alias Lighthouse.Categories.Repository
+  alias Lighthouse.Categories.Category
+  alias Lighthouse.Categories.CategoryFor
+
+  alias Lighthouse.Papers.Repository, as: PaperRepository
+
+  test "saves a relation to a paper" do
+    paper = PaperRepository.save(Lighthouse.SampleData.sample_paper)
+    category = Repository.save(%Category{name: "my-category"})
+
+    CategoryFor.save_relation(paper, category)
+
+    assert CategoryFor.find_categories_for(paper) == [category]
+  end
+end

--- a/test/categories/category_for_paper_test.exs
+++ b/test/categories/category_for_paper_test.exs
@@ -1,12 +1,11 @@
 defmodule Lighthouse.Categories.CategoryForPaperTest do
   use Lighthouse.RepositoryCase
-  alias Lighthouse.Categories.Repository
   alias Lighthouse.Categories.Category
   alias Lighthouse.Categories.CategoryFor
 
   test "saves a relation to a paper" do
     paper = Lighthouse.SampleData.sample_paper |> Repo.insert!
-    category = Repository.save(%Category{name: "my-category"})
+    category = %Category{name: "my-category"}  |> Repo.insert!
 
     CategoryFor.save_relation(paper, category)
 

--- a/test/categories/repository_test.exs
+++ b/test/categories/repository_test.exs
@@ -4,6 +4,7 @@ defmodule Lighthouse.Categories.RepositoryTest do
   alias Lighthouse.Categories.Category
 
   alias Lighthouse.Books.Repository, as: BookRepository
+  alias Lighthouse.Papers.Repository, as: PaperRepository
 
   test "saves a category" do
     category = Repository.save(%Category{name: "my-category"})
@@ -17,5 +18,14 @@ defmodule Lighthouse.Categories.RepositoryTest do
     Repository.save_relation(category.name, book)
 
     assert Repository.find_categories_for(book) == [category]
+  end
+
+  test "saves a relation to a paper" do
+    paper = PaperRepository.save(Lighthouse.SampleData.sample_paper)
+    category = Repository.save(%Category{name: "my-category"})
+
+    Repository.save_relation(category.name, paper)
+
+    assert Repository.find_categories_for(paper) == [category]
   end
 end

--- a/test/categories/repository_test.exs
+++ b/test/categories/repository_test.exs
@@ -1,0 +1,21 @@
+defmodule Lighthouse.Categories.RepositoryTest do
+  use Lighthouse.RepositoryCase
+  alias Lighthouse.Categories.Repository
+  alias Lighthouse.Categories.Category
+
+  alias Lighthouse.Books.Repository, as: BookRepository
+
+  test "saves a category" do
+    category = Repository.save(%Category{name: "my-category"})
+    assert category.name == "my-category"
+  end
+
+  test "saves a relation to a book" do
+    book = BookRepository.save(Lighthouse.SampleData.sample_book)
+    category = Repository.save(%Category{name: "my-category"})
+
+    Repository.save_relation(category.name, book)
+
+    assert Repository.find_categories_for(book) == [category]
+  end
+end

--- a/test/categories/repository_test.exs
+++ b/test/categories/repository_test.exs
@@ -3,18 +3,13 @@ defmodule Lighthouse.Categories.RepositoryTest do
   alias Lighthouse.Categories.Repository
   alias Lighthouse.Categories.Category
 
-  test "saves a category" do
-    category = Repository.save(%Category{name: "my-category"})
-    assert category.name == "my-category"
-  end
-
   defimpl Lighthouse.Categories.CategoryFor, for: Integer do
     def save_relation(thing, name), do: {thing, name}
     def find_categories_for(thing), do: thing
   end
 
   test "saves a relation" do
-    category = Repository.save(%Category{name: "my-category"})
+    category = %Category{name: "my-category"} |> Repo.insert!
 
     assert Repository.save_relation(category.name, 1) == {1, category}
   end

--- a/test/categories/repository_test.exs
+++ b/test/categories/repository_test.exs
@@ -3,29 +3,23 @@ defmodule Lighthouse.Categories.RepositoryTest do
   alias Lighthouse.Categories.Repository
   alias Lighthouse.Categories.Category
 
-  alias Lighthouse.Books.Repository, as: BookRepository
-  alias Lighthouse.Papers.Repository, as: PaperRepository
-
   test "saves a category" do
     category = Repository.save(%Category{name: "my-category"})
     assert category.name == "my-category"
   end
 
-  test "saves a relation to a book" do
-    book = BookRepository.save(Lighthouse.SampleData.sample_book)
-    category = Repository.save(%Category{name: "my-category"})
-
-    Repository.save_relation(category.name, book)
-
-    assert Repository.find_categories_for(book) == [category]
+  defimpl Lighthouse.Categories.CategoryFor, for: Integer do
+    def save_relation(thing, name), do: {thing, name}
+    def find_categories_for(thing), do: thing
   end
 
-  test "saves a relation to a paper" do
-    paper = PaperRepository.save(Lighthouse.SampleData.sample_paper)
+  test "saves a relation" do
     category = Repository.save(%Category{name: "my-category"})
 
-    Repository.save_relation(category.name, paper)
+    assert Repository.save_relation(category.name, 1) == {1, category}
+  end
 
-    assert Repository.find_categories_for(paper) == [category]
+  test "retrieves categories" do
+    assert Repository.find_categories_for(1) == 1
   end
 end

--- a/test/papers/controller_test.exs
+++ b/test/papers/controller_test.exs
@@ -2,18 +2,18 @@ defmodule Lighthouse.Papers.ControllerTest do
   import Lighthouse.SampleData, only: [sample_paper: 0]
   use Lighthouse.ConnCase
   use Lighthouse.RepositoryCase
-  alias Lighthouse.Papers.Repository
+  alias Lighthouse.Repo
   alias Lighthouse.Categories.Repository, as: CategoryRepo
   alias Lighthouse.Categories.Category
 
   test "renders all papers" do
-    paper = Repository.save(sample_paper())
+    paper = Repo.insert!(sample_paper())
     conn = get conn(), "/papers"
     assert html_response(conn, 200) =~ paper.title
   end
 
   test "renders a specific paper" do
-    paper = Repository.save(sample_paper())
+    paper = Repo.insert!(sample_paper())
     conn = get conn(), "/papers/#{paper.slug}"
     assert html_response(conn, 200) =~ paper.title
   end

--- a/test/papers/controller_test.exs
+++ b/test/papers/controller_test.exs
@@ -3,6 +3,8 @@ defmodule Lighthouse.Papers.ControllerTest do
   use Lighthouse.ConnCase
   use Lighthouse.RepositoryCase
   alias Lighthouse.Papers.Repository
+  alias Lighthouse.Categories.Repository, as: CategoryRepo
+  alias Lighthouse.Categories.Category
 
   test "renders all papers" do
     paper = Repository.save(sample_paper())
@@ -34,5 +36,22 @@ defmodule Lighthouse.Papers.ControllerTest do
 
     conn = get conn(), "/papers/#{params["slug"]}"
     assert html_response(conn, 200)
+  end
+
+  test "adds a paper with a category" do
+    category = CategoryRepo.save(%Category{name: "marketing"})
+
+    params = %{
+      "title"       => "a",
+      "author"      => "b",
+      "slug"        => "abc",
+      "description" => "d",
+      "link"        => "e"
+    }
+
+    post conn(), "/papers", %{"paper" => params, "category": category.name}
+
+    conn = get conn(), "/papers/#{params["slug"]}"
+    assert html_response(conn, 200) =~ category.name
   end
 end

--- a/test/papers/controller_test.exs
+++ b/test/papers/controller_test.exs
@@ -3,7 +3,6 @@ defmodule Lighthouse.Papers.ControllerTest do
   use Lighthouse.ConnCase
   use Lighthouse.RepositoryCase
   alias Lighthouse.Repo
-  alias Lighthouse.Categories.Repository, as: CategoryRepo
   alias Lighthouse.Categories.Category
 
   test "renders all papers" do
@@ -39,7 +38,7 @@ defmodule Lighthouse.Papers.ControllerTest do
   end
 
   test "adds a paper with a category" do
-    category = CategoryRepo.save(%Category{name: "marketing"})
+    category = %Category{name: "marketing"} |> Repo.insert!
 
     params = %{
       "title"       => "a",

--- a/test/papers/query_test.exs
+++ b/test/papers/query_test.exs
@@ -1,29 +1,29 @@
-defmodule Lighthouse.Papers.RepositoryTest do
+defmodule Lighthouse.Papers.QueryTest do
   import Lighthouse.SampleData, only: [sample_paper: 0]
   use Lighthouse.RepositoryCase
-  alias Lighthouse.Papers.Repository
+  alias Lighthouse.Papers.Query
 
   test "finds all papers" do
     sample_paper() |> Repo.insert!
     sample_paper() |> Repo.insert!
 
-    assert Repository.all() |> Enum.count == 2
+    assert Query.all() |> Enum.count == 2
   end
 
   test "find a paper by slug" do
     paper = sample_paper() |> Repo.insert!
-    assert Repository.find_by_slug(paper.slug)
+    assert Query.find_by_slug(paper.slug)
   end
 
   test "can find a paper by partial title" do
     paper = sample_paper() |> Repo.insert!
-    result = Repository.search(paper.title)
+    result = Query.search(paper.title)
     assert Enum.count(result) == 1
   end
 
   test "can find a paper by partial author" do
     paper = sample_paper() |> Repo.insert!
-    result = Repository.search(paper.author)
+    result = Query.search(paper.author)
     assert Enum.count(result) == 1
   end
 end

--- a/test/papers/repository_test.exs
+++ b/test/papers/repository_test.exs
@@ -3,33 +3,27 @@ defmodule Lighthouse.Papers.RepositoryTest do
   use Lighthouse.RepositoryCase
   alias Lighthouse.Papers.Repository
 
-  test "save a paper to the database" do
-    paper = sample_paper()
-    saved_paper = Repository.save(paper)
-    assert saved_paper.title == paper.title
-  end
-
   test "finds all papers" do
-    sample_paper() |> Repository.save
-    sample_paper() |> Repository.save
+    sample_paper() |> Repo.insert!
+    sample_paper() |> Repo.insert!
 
     assert Repository.all() |> Enum.count == 2
   end
 
   test "find a paper by slug" do
-    paper = sample_paper() |> Repository.save
+    paper = sample_paper() |> Repo.insert!
     assert Repository.find_by_slug(paper.slug)
   end
 
   test "can find a paper by partial title" do
-    Repository.save(sample_paper())
-    result = Repository.search("Fancy")
+    paper = sample_paper() |> Repo.insert!
+    result = Repository.search(paper.title)
     assert Enum.count(result) == 1
   end
 
   test "can find a paper by partial author" do
-    Repository.save(sample_paper())
-    result = Repository.search("Esquire")
+    paper = sample_paper() |> Repo.insert!
+    result = Repository.search(paper.author)
     assert Enum.count(result) == 1
   end
 end

--- a/test/search/controller_test.exs
+++ b/test/search/controller_test.exs
@@ -1,14 +1,11 @@
 defmodule Lighthouse.Search.ControllerTest do
-  import Lighthouse.SampleData, only: [sample_paper: 1,
-                                       sample_book: 1]
+  import Lighthouse.SampleData, only: [sample_paper: 1, sample_book: 1]
   use Lighthouse.ConnCase
   use Lighthouse.RepositoryCase
-  alias Lighthouse.Books.Repository, as: Books
-  alias Lighthouse.Papers.Repository, as: Papers
 
   test "finds both books and papers" do
-    Books.save(sample_book("That Cloud"))
-    Papers.save(sample_paper("Some Cloud"))
+    sample_book("That Cloud")  |> Repo.insert!
+    sample_paper("Some Cloud") |> Repo.insert!
 
     conn = post conn(), "/search", %{"query" => "cloud" }
     response = html_response(conn, 200)

--- a/test/search/searcher_test.exs
+++ b/test/search/searcher_test.exs
@@ -1,9 +1,6 @@
 defmodule Lighthouse.Search.SearchTest do
   use Lighthouse.RepositoryCase
-  import Lighthouse.SampleData, only: [sample_paper: 1,
-                                       sample_book: 1]
-  alias Lighthouse.Books.Repository, as: BooksRepo
-  alias Lighthouse.Papers.Repository, as: PapersRepo
+  import Lighthouse.SampleData, only: [sample_paper: 1, sample_book: 1]
   alias Lighthouse.Searcher
 
   test "reutrns nothing if it can't be found" do
@@ -12,24 +9,24 @@ defmodule Lighthouse.Search.SearchTest do
   end
 
   test "can find a given book by title" do
-    BooksRepo.save(sample_book("That book"))
+    book = sample_book("That book") |> Repo.insert!
 
-    result = Searcher.look_for("That book")
+    result = Searcher.look_for(book.title)
     assert Enum.count(result) == 1
   end
 
   test "finds only books with keyword in title" do
-    BooksRepo.save(sample_book("That book"))
-    BooksRepo.save(sample_book("Not it"))
+    book = sample_book("That book") |> Repo.insert!
+    sample_book("Not it") |> Repo.insert!
 
-    result = Searcher.look_for("That book")
+    result = Searcher.look_for(book.title)
     assert Enum.count(result) == 1
   end
 
   test "finds both books and papers" do
-    BooksRepo.save(sample_book("nothing"))
-    BooksRepo.save(sample_book("That Cloud"))
-    PapersRepo.save(sample_paper("Some Cloud"))
+    sample_book("Nothing")     |> Repo.insert!
+    sample_book("That Cloud")  |> Repo.insert!
+    sample_paper("Some Cloud") |> Repo.insert!
 
     result = Searcher.look_for("Cloud")
     assert Enum.count(result) == 2

--- a/test/support/repository_case.ex
+++ b/test/support/repository_case.ex
@@ -1,6 +1,12 @@
 defmodule Lighthouse.RepositoryCase do
   use ExUnit.CaseTemplate
 
+  using do
+    quote do
+      alias Lighthouse.Repo
+    end
+  end
+
   setup tags do
     unless tags[:async] do
       Ecto.Adapters.SQL.restart_test_transaction(Lighthouse.Repo, [])

--- a/web/books/controller.ex
+++ b/web/books/controller.ex
@@ -5,13 +5,12 @@ defmodule Lighthouse.Books.Controller do
   alias Lighthouse.Books.SearchByIsbn
   alias Lighthouse.Categories.Repository, as: CategoryRepo
 
-  def index(conn, _params) do
+  def index(conn, _) do
     render conn, "index.html", books: Repository.all()
   end
 
-  def add(conn, _params) do
-    conn
-    |> render "create.html"
+  def add(conn, _) do
+    render conn, "create.html"
   end
 
   def create(conn, %{"book" => book, "category" => category}) do
@@ -23,8 +22,7 @@ defmodule Lighthouse.Books.Controller do
   end
 
   def create(conn, %{"book" => book}) do
-    Book.changeset(%Book{}, book)
-    |> Repository.save
+    %Book{} |> Book.changeset(book) |> Repository.save
 
     redirect conn, to: "/books"
   end
@@ -34,29 +32,13 @@ defmodule Lighthouse.Books.Controller do
 
     categories = CategoryRepo.find_categories_for(book)
 
-    conn
-    |> assign(:book, book)
-    |> assign(:categories, categories)
-    |> render "book.html"
+    render conn, "book.html", book: book, categories: categories
   end
 
   def form(conn, %{"slug" => slug}) do
-    slug
-    |> Repository.find_by_slug
-    |> show_form(conn)
-  end
+    {:ok, book} = Repository.find_by_slug(slug)
 
-  defp show_form({:ok, book}, conn) do
-    conn
-    |> assign(:book, book)
-    |> render "form.html"
-  end
-
-  def edit(conn, %{"slug" => slug, "book" => data}) do
-    slug
-    |> Repository.find_by_slug
-    |> update(data)
-    |> view(conn)
+    render conn, "form.html", book: book
   end
 
   def lookup(conn, %{"isbn" => isbn}) do
@@ -66,12 +48,11 @@ defmodule Lighthouse.Books.Controller do
     end
   end
 
-  defp update({:ok, book}, data), do: Repository.update_book(book, data)
+  def edit(conn, %{"slug" => slug, "book" => data}) do
+    {:ok, book} = slug |> Repository.find_by_slug
+    book = book
+    |> Repository.update_book(data)
 
-  defp view(book, conn) do
-    conn
-    |> assign(:book, book)
-    |> assign(:categories, [])
-    |> render "book.html"
+    render conn, "book.html", book: book, categories: []
   end
 end

--- a/web/books/controller.ex
+++ b/web/books/controller.ex
@@ -1,13 +1,13 @@
 defmodule Lighthouse.Books.Controller do
   use Lighthouse.Web, :controller
   alias Lighthouse.Repo
-  alias Lighthouse.Books.Repository
+  alias Lighthouse.Books.Query
   alias Lighthouse.Books.Book
   alias Lighthouse.Books.SearchByIsbn
   alias Lighthouse.Categories.Repository, as: CategoryRepo
 
   def index(conn, _) do
-    render conn, "index.html", books: Repository.all()
+    render conn, "index.html", books: Query.all()
   end
 
   def add(conn, _) do
@@ -29,7 +29,7 @@ defmodule Lighthouse.Books.Controller do
   end
 
   def show(conn, %{"slug" => slug}) do
-    {:ok, book} = Repository.find_by_slug(slug)
+    {:ok, book} = Query.find_by_slug(slug)
 
     categories = CategoryRepo.find_categories_for(book)
 
@@ -37,7 +37,7 @@ defmodule Lighthouse.Books.Controller do
   end
 
   def form(conn, %{"slug" => slug}) do
-    {:ok, book} = Repository.find_by_slug(slug)
+    {:ok, book} = Query.find_by_slug(slug)
 
     render conn, "form.html", book: book
   end
@@ -50,7 +50,7 @@ defmodule Lighthouse.Books.Controller do
   end
 
   def edit(conn, %{"slug" => slug, "book" => data}) do
-    {:ok, book} = slug |> Repository.find_by_slug
+    {:ok, book} = slug |> Query.find_by_slug
     updated_book = book |> Book.changeset(data) |> Repo.update!
 
     render conn, "book.html", book: updated_book, categories: []

--- a/web/books/controller.ex
+++ b/web/books/controller.ex
@@ -1,5 +1,6 @@
 defmodule Lighthouse.Books.Controller do
   use Lighthouse.Web, :controller
+  alias Lighthouse.Repo
   alias Lighthouse.Books.Repository
   alias Lighthouse.Books.Book
   alias Lighthouse.Books.SearchByIsbn
@@ -14,7 +15,7 @@ defmodule Lighthouse.Books.Controller do
   end
 
   def create(conn, %{"book" => book, "category" => category}) do
-    book = %Book{} |> Book.changeset(book) |> Repository.save
+    book = %Book{} |> Book.changeset(book) |> Repo.insert!
 
     CategoryRepo.save_relation(category, book)
 
@@ -22,7 +23,7 @@ defmodule Lighthouse.Books.Controller do
   end
 
   def create(conn, %{"book" => book}) do
-    %Book{} |> Book.changeset(book) |> Repository.save
+    %Book{} |> Book.changeset(book) |> Repo.insert!
 
     redirect conn, to: "/books"
   end
@@ -50,9 +51,8 @@ defmodule Lighthouse.Books.Controller do
 
   def edit(conn, %{"slug" => slug, "book" => data}) do
     {:ok, book} = slug |> Repository.find_by_slug
-    book = book
-    |> Repository.update_book(data)
+    updated_book = book |> Book.changeset(data) |> Repo.update!
 
-    render conn, "book.html", book: book, categories: []
+    render conn, "book.html", book: updated_book, categories: []
   end
 end

--- a/web/books/controller.ex
+++ b/web/books/controller.ex
@@ -29,17 +29,14 @@ defmodule Lighthouse.Books.Controller do
   end
 
   def show(conn, %{"slug" => slug}) do
-    {:ok, book} = Query.find_by_slug(slug)
-
+    book = Query.find_by_slug(slug)
     categories = CategoryRepo.find_categories_for(book)
 
     render conn, "book.html", book: book, categories: categories
   end
 
   def form(conn, %{"slug" => slug}) do
-    {:ok, book} = Query.find_by_slug(slug)
-
-    render conn, "form.html", book: book
+    render conn, "form.html", book: Query.find_by_slug(slug)
   end
 
   def lookup(conn, %{"isbn" => isbn}) do
@@ -50,9 +47,11 @@ defmodule Lighthouse.Books.Controller do
   end
 
   def edit(conn, %{"slug" => slug, "book" => data}) do
-    {:ok, book} = slug |> Query.find_by_slug
-    updated_book = book |> Book.changeset(data) |> Repo.update!
+    book = slug
+    |> Query.find_by_slug
+    |> Book.changeset(data)
+    |> Repo.update!
 
-    render conn, "book.html", book: updated_book, categories: []
+    render conn, "book.html", book: book, categories: []
   end
 end

--- a/web/books/controller.ex
+++ b/web/books/controller.ex
@@ -35,7 +35,7 @@ defmodule Lighthouse.Books.Controller do
     render conn, "book.html", book: book, categories: categories
   end
 
-  def form(conn, %{"slug" => slug}) do
+  def edit(conn, %{"slug" => slug}) do
     render conn, "form.html", book: Query.find_by_slug(slug)
   end
 
@@ -46,7 +46,7 @@ defmodule Lighthouse.Books.Controller do
     end
   end
 
-  def edit(conn, %{"slug" => slug, "book" => data}) do
+  def update(conn, %{"slug" => slug, "book" => data}) do
     book = slug
     |> Query.find_by_slug
     |> Book.changeset(data)

--- a/web/papers/controller.ex
+++ b/web/papers/controller.ex
@@ -2,6 +2,7 @@ defmodule Lighthouse.Papers.Controller do
   use Lighthouse.Web, :controller
   alias Lighthouse.Papers.Repository
   alias Lighthouse.Papers.Paper
+  alias Lighthouse.Categories.Repository, as: CategoryRepo
 
   def index(conn, _params) do
     conn
@@ -11,10 +12,20 @@ defmodule Lighthouse.Papers.Controller do
 
   def show(conn, %{"slug" => slug}) do
     paper = Repository.find_by_slug(slug)
+    categories = CategoryRepo.find_categories_for(paper)
 
     conn
     |> assign(:paper, paper)
+    |> assign(:categories, categories)
     |> render "show.html"
+  end
+
+  def create(conn, %{"paper" => params, "category" => category}) do
+    paper = %Paper{} |> Paper.changeset(params) |> Repository.save
+
+    CategoryRepo.save_relation(category, paper)
+
+    redirect conn, to: "/papers"
   end
 
   def create(conn, %{"paper" => params}) do

--- a/web/papers/controller.ex
+++ b/web/papers/controller.ex
@@ -1,5 +1,6 @@
 defmodule Lighthouse.Papers.Controller do
   use Lighthouse.Web, :controller
+  alias Lighthouse.Repo
   alias Lighthouse.Papers.Repository
   alias Lighthouse.Papers.Paper
   alias Lighthouse.Categories.Repository, as: CategoryRepo
@@ -16,7 +17,7 @@ defmodule Lighthouse.Papers.Controller do
   end
 
   def create(conn, %{"paper" => params, "category" => category}) do
-    paper = %Paper{} |> Paper.changeset(params) |> Repository.save
+    paper = %Paper{} |> Paper.changeset(params) |> Repo.insert!
 
     CategoryRepo.save_relation(category, paper)
 
@@ -24,7 +25,7 @@ defmodule Lighthouse.Papers.Controller do
   end
 
   def create(conn, %{"paper" => params}) do
-    %Paper{} |> Paper.changeset(params) |> Repository.save
+    %Paper{} |> Paper.changeset(params) |> Repo.insert!
 
     redirect conn, to: "/papers"
   end

--- a/web/papers/controller.ex
+++ b/web/papers/controller.ex
@@ -4,20 +4,15 @@ defmodule Lighthouse.Papers.Controller do
   alias Lighthouse.Papers.Paper
   alias Lighthouse.Categories.Repository, as: CategoryRepo
 
-  def index(conn, _params) do
-    conn
-    |> assign(:papers, Repository.all())
-    |> render "index.html"
+  def index(conn, _) do
+    render conn, "index.html", papers: Repository.all()
   end
 
   def show(conn, %{"slug" => slug}) do
     paper = Repository.find_by_slug(slug)
     categories = CategoryRepo.find_categories_for(paper)
 
-    conn
-    |> assign(:paper, paper)
-    |> assign(:categories, categories)
-    |> render "show.html"
+    render conn, "show.html", paper: paper, categories: categories
   end
 
   def create(conn, %{"paper" => params, "category" => category}) do
@@ -29,14 +24,12 @@ defmodule Lighthouse.Papers.Controller do
   end
 
   def create(conn, %{"paper" => params}) do
-    Paper.changeset(%Paper{}, params)
-    |> Repository.save
+    %Paper{} |> Paper.changeset(params) |> Repository.save
 
     redirect conn, to: "/papers"
   end
 
-  def add(conn, _params) do
-    conn
-    |> render "create.html"
+  def add(conn, _) do
+    render conn, "create.html"
   end
 end

--- a/web/papers/controller.ex
+++ b/web/papers/controller.ex
@@ -1,16 +1,16 @@
 defmodule Lighthouse.Papers.Controller do
   use Lighthouse.Web, :controller
   alias Lighthouse.Repo
-  alias Lighthouse.Papers.Repository
+  alias Lighthouse.Papers.Query
   alias Lighthouse.Papers.Paper
   alias Lighthouse.Categories.Repository, as: CategoryRepo
 
   def index(conn, _) do
-    render conn, "index.html", papers: Repository.all()
+    render conn, "index.html", papers: Query.all()
   end
 
   def show(conn, %{"slug" => slug}) do
-    paper = Repository.find_by_slug(slug)
+    paper = Query.find_by_slug(slug)
     categories = CategoryRepo.find_categories_for(paper)
 
     render conn, "show.html", paper: paper, categories: categories

--- a/web/router.ex
+++ b/web/router.ex
@@ -27,8 +27,8 @@ defmodule Lighthouse.Router do
     get  "/books/add",        Books.Controller,   :add,    as: :books
     post "/books",            Books.Controller,   :create, as: :books
     get  "/books/:slug",      Books.Controller,   :show,   as: :books
-    post "/books/:slug/edit", Books.Controller,   :edit,   as: :books
-    get  "/books/:slug/edit", Books.Controller,   :form,   as: :books
+    get  "/books/:slug/edit", Books.Controller,   :edit,   as: :books
+    post "/books/:slug/edit", Books.Controller,   :update, as: :books
 
     get  "/papers",           Papers.Controller,  :index
     post "/papers",           Papers.Controller,  :create, as: :papers

--- a/web/search/controller.ex
+++ b/web/search/controller.ex
@@ -5,8 +5,6 @@ defmodule Lighthouse.Search.Controller do
   def index(conn, %{"query" => query}) do
     results = Searcher.look_for(query)
 
-    conn
-    |> assign(:results, results)
-    |> render "index.html"
+    render conn, "index.html", results: results
   end
 end

--- a/web/templates/books/book.html.eex
+++ b/web/templates/books/book.html.eex
@@ -14,6 +14,12 @@
     <dd><%= @book.description %></dd>
   </dl>
 
+  <ul>
+  <%= for category <- @categories do %>
+    <li><%= category.name %></li>
+  <% end %>
+  </ul>
+
   <footer>
     <a href="<%= books_path(@conn, :edit, @book.slug) %>" class="button">Edit</a>
   </footer>

--- a/web/templates/papers/show.html.eex
+++ b/web/templates/papers/show.html.eex
@@ -9,4 +9,10 @@
 
   <p><%= @paper.description %></p>
   <p><%= @paper.link %></p>
+
+  <ul>
+  <%= for category <- @categories do %>
+    <li><%= category.name %></li>
+  <% end %>
+  </ul>
 </section>


### PR DESCRIPTION
There are some limitations currently:
* Only able to add categories through the db.
* Interface only supports adding one category per item.
* Papers and Books don't have the same interface (pre-existing issue).